### PR TITLE
docs: fix grammar in README and correct 'susbscribe' typo in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The `getKycStatus` return the KYC status of a user based on a user_token, issued
 user signed a Sign Request (from your app) before (see Payloads - Intro).
 
 If a user token specified is invalid, revoked, expired, etc. the method will always
-return `NONE`, just like when a user didn't go through KYC. You cannot distinct a non-KYC'd user
+return `NONE`, just like when a user didn't go through KYC. You cannot distinguish a non-KYC'd user
 from an invalid token.
 
 Alternatively, KYC status can be retrieved for an XPRL account address: the address selected in

--- a/test/payload-subscribe.ts
+++ b/test/payload-subscribe.ts
@@ -1,186 +1,239 @@
-import jsonFixtures from './fixtures/xumm-api.json'
-import * as jestFixtures from './fixtures/xumm-api'
-import fetchMock from 'jest-fetch-mock'
+import jsonFixtures from "./fixtures/xumm-api.json";
+import * as jestFixtures from "./fixtures/xumm-api";
+import fetchMock from "jest-fetch-mock";
 
-fetchMock.enableMocks()
+fetchMock.enableMocks();
 
-import {XummSdk, XummTypes} from '../src/'
-import {Server, WebSocket as MockedWebSocket} from 'mock-socket'
+import { XummSdk, XummTypes } from "../src/";
+import { Server, WebSocket as MockedWebSocket } from "mock-socket";
 
-const wsEol = [MockedWebSocket.CLOSED, MockedWebSocket.CLOSING]
+const wsEol = [MockedWebSocket.CLOSED, MockedWebSocket.CLOSING];
 
-let mockServer: Server
+let mockServer: Server;
 
 beforeAll(() => {
-  Object.assign(global, {MockedWebSocket})
+  Object.assign(global, { MockedWebSocket });
 
-  mockServer = new Server('ws://xumm.local')
+  mockServer = new Server("ws://xumm.local");
 
-  mockServer.on('connection', socket => {
-    socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.welcome))
-
-    setTimeout(() => {
-      socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.expire))
-    }, 150)
+  mockServer.on("connection", (socket) => {
+    socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.welcome));
 
     setTimeout(() => {
-      socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.opened))
-    }, 250)
+      socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.expire));
+    }, 150);
 
     setTimeout(() => {
-      socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.rejected))
-    }, 350)
-  })
-})
+      socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.opened));
+    }, 250);
+
+    setTimeout(() => {
+      socket.send(JSON.stringify(jestFixtures.subscriptionUpdates.rejected));
+    }, 350);
+  });
+});
 
 afterAll(() => {
-  mockServer.close()
-})
+  mockServer.close();
+});
 
-describe('XUMM Payload Subscriptions', () => {
-  process.env.XUMM_APIKEY = jsonFixtures.api.key
-  process.env.XUMM_APISECRET = jsonFixtures.api.secret
+describe("XUMM Payload Subscriptions", () => {
+  process.env.XUMM_APIKEY = jsonFixtures.api.key;
+  process.env.XUMM_APISECRET = jsonFixtures.api.secret;
 
-  const Sdk = new XummSdk()
+  const Sdk = new XummSdk();
 
-  it('should susbscribe & resolve using inner resolve method @ callback', async () => {
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get))
+  it("should subscribe & resolve using inner resolve method @ callback", async () => {
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get));
 
-    const subscriptionSocket = await Sdk.payload.subscribe('0ef943e9-18ae-4fa2-952a-6f55dce363f0', event => {
-      if (typeof event.data.signed !== 'undefined') {
-        return event.resolve(event.data)
+    const subscriptionSocket = await Sdk.payload.subscribe(
+      "0ef943e9-18ae-4fa2-952a-6f55dce363f0",
+      (event) => {
+        if (typeof event.data.signed !== "undefined") {
+          return event.resolve(event.data);
+        }
       }
-    })
+    );
 
     expect(subscriptionSocket).toMatchObject({
       payload: jsonFixtures.payload.get,
       resolve: expect.any(Function),
       resolved: expect.any(Promise),
-      websocket: expect.any(MockedWebSocket)
-    })
+      websocket: expect.any(MockedWebSocket),
+    });
 
-    await new Promise(resolve => subscriptionSocket.websocket.onopen = resolve)
+    await new Promise(
+      (resolve) => (subscriptionSocket.websocket.onopen = resolve)
+    );
 
-    expect(subscriptionSocket.websocket.readyState).toEqual(subscriptionSocket.websocket.OPEN)
-    expect(await subscriptionSocket.resolved).toMatchObject(jestFixtures.subscriptionUpdates.rejected)
-    expect(wsEol).toEqual(expect.arrayContaining([subscriptionSocket.websocket.readyState]))
+    expect(subscriptionSocket.websocket.readyState).toEqual(
+      subscriptionSocket.websocket.OPEN
+    );
+    expect(await subscriptionSocket.resolved).toMatchObject(
+      jestFixtures.subscriptionUpdates.rejected
+    );
+    expect(wsEol).toEqual(
+      expect.arrayContaining([subscriptionSocket.websocket.readyState])
+    );
 
-    return
-  })
+    return;
+  });
 
-  it('should susbscribe & resolve using return @ callback', async () => {
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get))
+  it("should subscribe & resolve using return @ callback", async () => {
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get));
 
-    const subscriptionSocket = await Sdk.payload.subscribe('0ef943e9-18ae-4fa2-952a-6f55dce363f0', event => {
-      if (typeof event.data.signed !== 'undefined') {
-        return event.data
+    const subscriptionSocket = await Sdk.payload.subscribe(
+      "0ef943e9-18ae-4fa2-952a-6f55dce363f0",
+      (event) => {
+        if (typeof event.data.signed !== "undefined") {
+          return event.data;
+        }
       }
-    })
+    );
 
     expect(subscriptionSocket).toMatchObject({
       payload: jsonFixtures.payload.get,
       resolve: expect.any(Function),
       resolved: expect.any(Promise),
-      websocket: expect.any(MockedWebSocket)
-    })
+      websocket: expect.any(MockedWebSocket),
+    });
 
-    await new Promise(resolve => subscriptionSocket.websocket.onopen = resolve)
+    await new Promise(
+      (resolve) => (subscriptionSocket.websocket.onopen = resolve)
+    );
 
-    expect(subscriptionSocket.websocket.readyState).toEqual(subscriptionSocket.websocket.OPEN)
-    expect(await subscriptionSocket.resolved).toMatchObject(jestFixtures.subscriptionUpdates.rejected)
-    expect(wsEol).toEqual(expect.arrayContaining([subscriptionSocket.websocket.readyState]))
+    expect(subscriptionSocket.websocket.readyState).toEqual(
+      subscriptionSocket.websocket.OPEN
+    );
+    expect(await subscriptionSocket.resolved).toMatchObject(
+      jestFixtures.subscriptionUpdates.rejected
+    );
+    expect(wsEol).toEqual(
+      expect.arrayContaining([subscriptionSocket.websocket.readyState])
+    );
 
-    return
-  })
+    return;
+  });
 
-  it('should susbscribe & resolve using obj.resolve() method', async () => {
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get))
+  it("should subscribe & resolve using obj.resolve() method", async () => {
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get));
 
-    const subscriptionSocket = await Sdk.payload.subscribe('0ef943e9-18ae-4fa2-952a-6f55dce363f0')
+    const subscriptionSocket = await Sdk.payload.subscribe(
+      "0ef943e9-18ae-4fa2-952a-6f55dce363f0"
+    );
 
     expect(subscriptionSocket).toMatchObject({
       payload: jsonFixtures.payload.get,
       resolve: expect.any(Function),
       resolved: expect.any(Promise),
-      websocket: expect.any(MockedWebSocket)
-    })
+      websocket: expect.any(MockedWebSocket),
+    });
 
-    await new Promise(resolve => subscriptionSocket.websocket.onopen = resolve)
+    await new Promise(
+      (resolve) => (subscriptionSocket.websocket.onopen = resolve)
+    );
 
-    expect(subscriptionSocket.websocket.readyState).toEqual(subscriptionSocket.websocket.OPEN)
+    expect(subscriptionSocket.websocket.readyState).toEqual(
+      subscriptionSocket.websocket.OPEN
+    );
 
-    let receivedWsMessages = 0
-    subscriptionSocket.websocket.onmessage = () => receivedWsMessages++
+    let receivedWsMessages = 0;
+    subscriptionSocket.websocket.onmessage = () => receivedWsMessages++;
 
     setTimeout(() => {
-      subscriptionSocket.resolve({dummyObject: true})
-      expect(receivedWsMessages).toEqual(3)
-    }, 500)
+      subscriptionSocket.resolve({ dummyObject: true });
+      expect(receivedWsMessages).toEqual(3);
+    }, 500);
 
-    expect(await subscriptionSocket.resolved).toMatchObject({dummyObject: true})
-    expect(wsEol).toEqual(expect.arrayContaining([subscriptionSocket.websocket.readyState]))
+    expect(await subscriptionSocket.resolved).toMatchObject({
+      dummyObject: true,
+    });
+    expect(wsEol).toEqual(
+      expect.arrayContaining([subscriptionSocket.websocket.readyState])
+    );
 
-    return
-  })
+    return;
+  });
 
-  it('should create, susbscribe & resolve using return @ callback', async () => {
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.created))
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get))
+  it("should create, subscribe & resolve using return @ callback", async () => {
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.created));
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get));
 
-    const payload = jestFixtures.validPayload as XummTypes.XummPostPayloadBodyJson
-    const createdAndSubscribed = await Sdk.payload.createAndSubscribe(payload, event => {
-      if (typeof event.data.signed !== 'undefined') {
-        return event.data
+    const payload =
+      jestFixtures.validPayload as XummTypes.XummPostPayloadBodyJson;
+    const createdAndSubscribed = await Sdk.payload.createAndSubscribe(
+      payload,
+      (event) => {
+        if (typeof event.data.signed !== "undefined") {
+          return event.data;
+        }
       }
-    })
+    );
 
     expect(createdAndSubscribed).toMatchObject({
       created: jestFixtures.createPayloadResponseObject,
       payload: jsonFixtures.payload.get,
       resolve: expect.any(Function),
       resolved: expect.any(Promise),
-      websocket: expect.any(MockedWebSocket)
-    })
+      websocket: expect.any(MockedWebSocket),
+    });
 
-    await new Promise(resolve => createdAndSubscribed.websocket.onopen = resolve)
+    await new Promise(
+      (resolve) => (createdAndSubscribed.websocket.onopen = resolve)
+    );
 
-    expect(createdAndSubscribed.websocket.readyState).toEqual(createdAndSubscribed.websocket.OPEN)
-    expect(await createdAndSubscribed.resolved).toMatchObject(jestFixtures.subscriptionUpdates.rejected)
-    expect(wsEol).toEqual(expect.arrayContaining([createdAndSubscribed.websocket.readyState]))
+    expect(createdAndSubscribed.websocket.readyState).toEqual(
+      createdAndSubscribed.websocket.OPEN
+    );
+    expect(await createdAndSubscribed.resolved).toMatchObject(
+      jestFixtures.subscriptionUpdates.rejected
+    );
+    expect(wsEol).toEqual(
+      expect.arrayContaining([createdAndSubscribed.websocket.readyState])
+    );
 
-    return
-  })
+    return;
+  });
 
-  it('should create, susbscribe & resolve using using obj.resolve() method', async () => {
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.created))
-    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get))
+  it("should create, subscribe & resolve using using obj.resolve() method", async () => {
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.created));
+    fetchMock.doMockOnce(JSON.stringify(jsonFixtures.payload.get));
 
-    const payload = jestFixtures.validPayload as XummTypes.XummPostPayloadBodyJson
-    const createdAndSubscribed = await Sdk.payload.createAndSubscribe(payload)
+    const payload =
+      jestFixtures.validPayload as XummTypes.XummPostPayloadBodyJson;
+    const createdAndSubscribed = await Sdk.payload.createAndSubscribe(payload);
 
     expect(createdAndSubscribed).toMatchObject({
       created: jestFixtures.createPayloadResponseObject,
       payload: jsonFixtures.payload.get,
       resolve: expect.any(Function),
       resolved: expect.any(Promise),
-      websocket: expect.any(MockedWebSocket)
-    })
+      websocket: expect.any(MockedWebSocket),
+    });
 
-    await new Promise(resolve => createdAndSubscribed.websocket.onopen = resolve)
+    await new Promise(
+      (resolve) => (createdAndSubscribed.websocket.onopen = resolve)
+    );
 
-    expect(createdAndSubscribed.websocket.readyState).toEqual(createdAndSubscribed.websocket.OPEN)
+    expect(createdAndSubscribed.websocket.readyState).toEqual(
+      createdAndSubscribed.websocket.OPEN
+    );
 
-    let receivedWsMessages = 0
-    createdAndSubscribed.websocket.onmessage = () => receivedWsMessages++
+    let receivedWsMessages = 0;
+    createdAndSubscribed.websocket.onmessage = () => receivedWsMessages++;
 
     setTimeout(() => {
-      createdAndSubscribed.resolve({dummyObject: true})
-      expect(receivedWsMessages).toEqual(3)
-    }, 500)
+      createdAndSubscribed.resolve({ dummyObject: true });
+      expect(receivedWsMessages).toEqual(3);
+    }, 500);
 
-    expect(await createdAndSubscribed.resolved).toMatchObject({dummyObject: true})
-    expect(wsEol).toEqual(expect.arrayContaining([createdAndSubscribed.websocket.readyState]))
+    expect(await createdAndSubscribed.resolved).toMatchObject({
+      dummyObject: true,
+    });
+    expect(wsEol).toEqual(
+      expect.arrayContaining([createdAndSubscribed.websocket.readyState])
+    );
 
-    return
-  })
-})
+    return;
+  });
+});


### PR DESCRIPTION
Summary of what was fixed:

Corrected the grammar in the README: "You cannot distinct..." → "You cannot distinguish..."
Corrected all instances of the typo "susbscribe" → "subscribe" in test/payload-subscribe.ts.